### PR TITLE
fix issue found in the template

### DIFF
--- a/examples/08-subtemplate/template.generated.txt
+++ b/examples/08-subtemplate/template.generated.txt
@@ -4,7 +4,7 @@
     street: <no value> <no value>
  - labels:
     app: nginx
-    name: .Name
+    name: John Doe
     street: <no value> <no value>
  - labels:
     app: nginx

--- a/examples/08-subtemplate/template.tpl
+++ b/examples/08-subtemplate/template.tpl
@@ -9,7 +9,7 @@
  - labels:
     app: nginx
     {{- if .Name}}
-    name: .Name
+    name: {{ .Name }}
     {{- end}}
     street: {{ .Street }} {{ .City }}
 {{- end }}


### PR DESCRIPTION
Fix a small issue found in the template code

Before, the generated content is:
```
 - labels:
    app: nginx
    street: <no value> <no value>
 - labels:
    app: nginx
    name:  .Name
    street: <no value> <no value>
 - labels:
    app: nginx
    street: Main st 8 NY
```

Now it becomes
```
 - labels:
    app: nginx
    street: <no value> <no value>
 - labels:
    app: nginx
    name: John Doe
    street: <no value> <no value>
 - labels:
    app: nginx
    street: Main st 8 NY
```